### PR TITLE
chore: authorize long lines in commit 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,108 @@
+# Contributing
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+
+## Found an Issue?
+
+Thank you for reporting any issues you find. We do our best to test and make this product as solid as possible, but any reported issue is a real help.
+
+Please follow these guidelines when reporting issues:
+
+- Provide a title in the format of `<Error> when <Task>`
+- Tag your issue with the tag `bug`
+- Provide a short summary of what you are trying to do
+- Provide the log of the encountered error if applicable
+- Provide the exact version
+- Be awesome and consider contributing a [pull request](#want-to-contribute)
+
+## Want to contribute?
+
+You consider contributing changes – we dig that!
+Please consider these guidelines when filing a pull request:
+
+- Always start from main branch
+- Follow the [Coding Rules](#coding-rules)
+- Follow [Git rebase strategy](https://www.freecodecamp.org/news/an-introduction-to-git-merge-and-rebase-what-they-are-and-how-to-use-them-131b863785f/#:~:text=of%20both%20branches.-,Git%20Rebase,from%20one%20branch%20to%20another.)
+- Follow [Test guidelines](#tests)
+- Follow [Hook guidelines](#git-hook)
+- Follow the [Commit Rules](#commit-rules)
+- Follow [PR guidelines](#pull-request)
+- Make sure you rebased the current main branch when filing the pull request
+- For significant changes, post also an issue before to know if your idea has a chance to be accepted
+
+## Coding Rules
+
+To keep the code base of commitlint neat and tidy the following rules apply to every change
+
+- `prettier` is king
+- `eslint` is awesome
+- Favor micro library over swiss army knives (rimraf, ncp vs. fs-extra)
+- Be awesome
+
+> use commands `yarn lint` and `yarn format` to be sure your code
+> respect coding rules.
+
+> You can also use `npx prettier --write .` to fix prettier errors
+
+## Commit Rules
+
+To help everyone with understanding the commit history of commitlint the following commit rules are enforced.
+
+- [conventional commits](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
+- present tense
+- maximum of 100 characters
+- for bugs, includes the github tag of the issue in the description.
+- message format of `$type($scope): $message`
+
+These are the authorized types:
+
+- build
+- ci
+- chore
+- docs
+- feat
+- fix
+- perf
+- refactor
+- revert
+- style
+- test
+
+> Using the right type is really important since it is used to increase the version number automatically.
+
+Also follow the following rules to ensure a good readibility of the commits
+
+- Provide a short title with a maximum of 100 characters
+- Provide a more detailed description containing
+  _ What you want to achieve
+  _ What you changed
+  _ What you added
+  _ What you removed
+
+## Git Hook
+
+In order to get feedbacks as soon as possible, we suggest to install git hooks to ensure your commits are compliant before writting them.
+Under the hood, it will automatically check the style, format, tests, commit messages, etc.
+After installing all the dependencies, please run the command below:
+
+```
+npx simple-git-hooks
+```
+
+> Remember to use this command everytime you change the hooks in the package.json
+
+## Pull Request
+
+The Pull Request title should follow the same template as commit title (see [commit rules](#commit-rules)). Please also follow the templates provided at the PR creation.
+
+## Test
+
+If you add a feature or fix a bug, you need to provide a test verifying your
+improvement. You can launch tests using `yarn test`.
+
+## Versioning
+
+We use [standard-version](https://github.com/conventional-changelog/standard-version) to handle versioning
+automatically.
+
+**May the force be with you !!**

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,6 @@
-module.exports = { extends: ['@commitlint/config-conventional'] }
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [2, 'always', 300],
+  },
+}


### PR DESCRIPTION
# Description

Deployment could fail if lines in commit where too long. 

# Technical details

- chore: change commit lint config
- docs: add contributing file

# Checklist:

- [x] I have read CONTRIBUTING.md before writing my PR
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
