### PR TITLE
fix: unlinked accounts

### DIFF
--- a/api/src/utils/cleanId.ts
+++ b/api/src/utils/cleanId.ts
@@ -1,0 +1,3 @@
+const cleanId = (email: string) => email.replace(/\./, '_')
+
+export default cleanId


### PR DESCRIPTION
# Description

Switching from firebase authentication to clerk authentication changed all the userId. Since the userIds were used to identify the users in the database, all the recipes (and other data) were unlinked from accounts. So the new id is the email

# Technical details

- fix: use email address to identify user in the database

> A migration of the production database has also been performed to change all the userIds.


# Checklist:

- [x] I have read CONTRIBUTING.md before writing my PR
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
